### PR TITLE
Issue: ServerConnection#close() ensures all messages in buffer  are sent before closing the channel.

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -67,7 +67,7 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
             writeAndFlush(c, cmd);
         }
     }
-    
+
     private static void writeAndFlush(Channel channel, WireCommand data) {
         channel.writeAndFlush(data).addListener(ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE);
     }  
@@ -82,7 +82,7 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
         Channel ch = channel.get();
         if (ch != null) {
             // wait for all messages to be sent before closing the channel.
-            channel.get().writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+            ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
         }
     }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -9,6 +9,7 @@
  */
 package io.pravega.segmentstore.server.host.handler;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -80,7 +81,8 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
     public void close() {
         Channel ch = channel.get();
         if (ch != null) {
-            ch.close();
+            // wait for all messages to be sent before closing the channel.
+            channel.get().writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
         }
     }
 


### PR DESCRIPTION
**Change log description**  
Ensure `ServerConnection#close() ` sends all messages in the buffer before closing the channel.

**Purpose of the change**  
(_e.g._, Fixes #666, Closes #1234)

**What the code does**  
Consider the following code snippet inside PravegaRequestProcessor

```
...if (u instanceof AuthenticationException) {
            log.warn(requestId, "Authentication error during '{}'.", operation);
            invokeSafely(connection::send, new AuthTokenCheckFailed(requestId, clientReplyStackTrace), failureHandler);
            connection.close();
        } 
```
In this case it can so happen that the `AuthTokenCheckFailed` message is never received by the client.
This PR ensures the channel is closed after all the message upto now are flushed and sent over the wire.

**How to verify it**  
All the existing tests should continue to pass.