### PR TITLE
Issue : Ensure Segment Server closes all idle connections.

### DIFF
--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -52,6 +52,7 @@ import static io.pravega.shared.protocol.netty.WireCommands.MAX_WIRECOMMAND_SIZE
  * Hands off any received data from a client to the CommandProcessor.
  */
 public final class PravegaConnectionListener implements AutoCloseable {
+    private static final long IDLE_TIMEOUT_SECONDS = 100L;
     //region Members
 
     private final boolean ssl;
@@ -161,7 +162,7 @@ public final class PravegaConnectionListener implements AutoCloseable {
                  }
                  ServerConnectionInboundHandler lsh = new ServerConnectionInboundHandler();
                  p.addLast(new ExceptionLoggingHandler(ch.remoteAddress().toString()),
-                         new IdleStateHandler(true, 0L, 0L, 10L, TimeUnit.SECONDS),
+                         new IdleStateHandler(true, 0L, 0L, IDLE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
                          new CommandEncoder(null),
                          new LengthFieldBasedFrameDecoder(MAX_WIRECOMMAND_SIZE, 4, 4),
                          new CommandDecoder(),

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/PravegaConnectionListener.java
@@ -28,6 +28,7 @@ import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.Slf4JLoggerFactory;
 import io.pravega.common.Exceptions;
@@ -42,6 +43,7 @@ import io.pravega.shared.protocol.netty.CommandDecoder;
 import io.pravega.shared.protocol.netty.CommandEncoder;
 import io.pravega.shared.protocol.netty.ExceptionLoggingHandler;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 
 import static io.pravega.shared.protocol.netty.WireCommands.MAX_WIRECOMMAND_SIZE;
@@ -159,6 +161,7 @@ public final class PravegaConnectionListener implements AutoCloseable {
                  }
                  ServerConnectionInboundHandler lsh = new ServerConnectionInboundHandler();
                  p.addLast(new ExceptionLoggingHandler(ch.remoteAddress().toString()),
+                         new IdleStateHandler(true, 0L, 0L, 10L, TimeUnit.SECONDS),
                          new CommandEncoder(null),
                          new LengthFieldBasedFrameDecoder(MAX_WIRECOMMAND_SIZE, 4, 4),
                          new CommandDecoder(),

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -104,7 +104,7 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt instanceof IdleStateEvent) {
             IdleStateEvent event = (IdleStateEvent) evt;
-            log.warn("Server - Channel {} is idle ({}), closing it", event.state(), ctx.channel());
+            log.warn("Server - Channel {} is idle ({}), closing it", ctx.channel(), event.state());
             ctx.close();
         }
 

--- a/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
+++ b/segmentstore/server/host/src/main/java/io/pravega/segmentstore/server/host/handler/ServerConnectionInboundHandler.java
@@ -14,6 +14,7 @@ import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.EventLoop;
+import io.netty.handler.timeout.IdleStateEvent;
 import io.pravega.common.Exceptions;
 import io.pravega.segmentstore.server.IllegalContainerStateException;
 import io.pravega.shared.protocol.netty.Request;
@@ -97,6 +98,17 @@ public class ServerConnectionInboundHandler extends ChannelInboundHandlerAdapter
     @Override
     public void resumeReading() {
         getChannel().config().setAutoRead(true);
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+        if (evt instanceof IdleStateEvent) {
+            IdleStateEvent event = (IdleStateEvent) evt;
+            log.warn("Server - Channel {} is idle ({}), closing it", event.state(), ctx.channel());
+            ctx.close();
+        }
+
+        ctx.fireUserEventTriggered(evt);
     }
 
     private Channel getChannel() {


### PR DESCRIPTION
**Change log description**  
Ensure Segment Server closes all idle connections.

**Purpose of the change**  
Fixes #issue

**What the code does**  
After a client establishes a connection it sends periodic keepAlives to the server
This ensures the connection does not timeout and it also enables early detection of connection failures.

During the investigation of issue 3900 it was observed that none of the connection was not dropped and 
neither were the messages delivered to the Segment store on time.

This PR ensures the Segment store detects such idle connections and ensures such connections are closed. In this PR we are choosing an idle timeout of 100 seconds. i.e. connections where writes and reads do not happen for more than `IDLE_TIMEOUT_SECONDS ` are closed by the IdleStateHandler.

The only open point with this approach is the the following issue
`https://github.com/netty/netty/issues/8912#issuecomment-486633037`.

**How to verify it**  
Verified that the channel is infact closed after the idle timeout.
